### PR TITLE
Use the TORCH_INSTALL env variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,8 @@ FIND_PACKAGE(Torch REQUIRED)  # you need to run source ~/torch/install/bin/torch
 SET(CMAKE_C_FLAGS "-std=c99 ")
 SET(CMAKE_CXX_FLAGS "-std=c++0x -Wall")
 
-set(HOME $ENV{HOME})
-#include_directories(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/lua-5.1.5/src)
-include_directories(${HOME}/torch/install/include/TH)
-include_directories(${HOME}/torch/install/include)
+include_directories(${TORCH_INSTALL}/include)
+include_directories(${TORCH_INSTALL}/include/TH)
 
 ADD_DEFINITIONS(-DLUA_USE_LINUX)
 

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ rm -Rf build PyBuild.so dist *.egg-info cbuild
 # python setup.py build_ext -i || exit 1
 if [[ x${CYTHON} != x ]]; then { python setup.py cython_only || exit 1; } fi
 mkdir cbuild
-TORCH_INSTALL=$(dirname $(dirname $(which luajit)))
+export TORCH_INSTALL=$(dirname $(dirname $(which luajit)))
 (cd cbuild; cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${TORCH_INSTALL} && make -j 4 install) || exit 1
 pip uninstall -y PyTorch
 python setup.py install || exit 1

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ import platform
 from setuptools import setup
 from setuptools import Extension
 
-home_dir = os.getenv('HOME')
-print('home_dir:', home_dir)
+torch_dir = os.getenv('TORCH_INSTALL')
+print('torch_install:', torch_dir)
 
 cython_present = False
 #from Cython.Build import cythonize
@@ -92,11 +92,11 @@ libraries.append('PyTorchNative')
 #libraries.append('TH')
 library_dirs = []
 # library_dirs.append('cbuild')
-library_dirs.append(home_dir + '/torch/install/lib')
+library_dirs.append(torch_dir + '/lib')
 
 runtime_library_dirs = []
 if osfamily != 'Windows':
-    runtime_library_dirs = [home_dir + '/torch/install/lib']
+    runtime_library_dirs = [torch_dir + '/lib']
 
 if osfamily == 'Windows':
     libraries.append('winmm')
@@ -120,7 +120,7 @@ for cython_source in cython_sources:
     ext_modules.append(
         Extension(basename,
                   sources=[source_name],
-                  include_dirs=[home_dir + '/torch/install/include/TH', 'thirdparty/lua-5.1.5/src', home_dir + '/torch/install/include'],
+                  include_dirs=[torch_dir + '/include/TH', 'thirdparty/lua-5.1.5/src', torch_dir + '/include'],
                   library_dirs=library_dirs,
                   libraries=libraries,
                   extra_compile_args=compile_options,


### PR DESCRIPTION
Since it is already advocated to use the build.sh script, we
might as well use the code that is smart enough to find the
lua/torch install directory in there to set the directory. So,
instead of assuming $HOME, we use $TORCH_INSTALL.

This was very useful for me where I have torch installed on
a network directory. Anyone using the default directory
should see no changes.